### PR TITLE
feat: add api key middleware

### DIFF
--- a/synced_bloc/lib/src/live_bloc.dart
+++ b/synced_bloc/lib/src/live_bloc.dart
@@ -35,6 +35,15 @@ abstract class LiveBloc<Event, State> extends Bloc<Event, State> {
 
   static http.Client client = http.Client();
 
+  static String? _apiKey;
+
+  static set apiKey(String? apiKey) => _apiKey = apiKey;
+
+  static String get apiKey {
+    if (_apiKey == null) throw Exception('API key not found');
+    return _apiKey!;
+  }
+
   late final WebSocket socket;
   late final StreamSubscription<dynamic> subscription;
 

--- a/synced_bloc/lib/src/synced_bloc.dart
+++ b/synced_bloc/lib/src/synced_bloc.dart
@@ -34,6 +34,15 @@ abstract class SyncedBloc<Event, State> extends Bloc<Event, State> {
 
   static http.Client client = http.Client();
 
+  static String? _apiKey;
+
+  static set apiKey(String? apiKey) => _apiKey = apiKey;
+
+  static String get apiKey {
+    if (_apiKey == null) throw Exception('API key not found');
+    return _apiKey!;
+  }
+
   State? _state;
 
   @override

--- a/synced_bloc_server/lib/src/api_key_middleware.dart
+++ b/synced_bloc_server/lib/src/api_key_middleware.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+
+/// Middleware to check if the API key is valid.
+Middleware apiKeyMiddleware() {
+  return (handler) {
+    return (context) async {
+      final apiKey = context.request.headers['x-api-key'];
+      final expectedApiKey = Platform.environment['API_KEY'];
+      if (apiKey != expectedApiKey) {
+        return Response(statusCode: 401);
+      }
+      return handler(context);
+    };
+  };
+}

--- a/synced_bloc_server/routes/_middleware.dart
+++ b/synced_bloc_server/routes/_middleware.dart
@@ -1,5 +1,6 @@
 import 'package:dart_frog/dart_frog.dart';
+import 'package:synced_bloc_server/src/api_key_middleware.dart';
 
 Handler middleware(Handler handler) {
-  return handler.use(requestLogger());
+  return handler.use(requestLogger()).use(apiKeyMiddleware());
 }


### PR DESCRIPTION
This pull request introduces API key management and validation functionality across both the client and server sides of the `synced_bloc` project. Key changes include adding static API key handling in client classes and implementing middleware for API key validation on the server.

### API Key Management in Client Code:

* [`synced_bloc/lib/src/live_bloc.dart`](diffhunk://#diff-b48600d1128057feb1fb5d6ea5e80e4ed66f8dfa1ad5b7f44af3e7c7b3ec0557R38-R46): Added static `_apiKey` field with getter and setter methods for managing the API key. The getter throws an exception if the key is not set.
* [`synced_bloc/lib/src/synced_bloc.dart`](diffhunk://#diff-ab1cfe58ddec98dfb74328393ad87c858bc72c9cc6650a4f75ea9ec2d386bc5bR37-R45): Mirrored the same API key management functionality as in `LiveBloc`, including the `_apiKey` field, getter, and setter methods.

### API Key Validation on the Server:

* [`synced_bloc_server/lib/src/api_key_middleware.dart`](diffhunk://#diff-7f580e9cda2d7efe5e0c6389b07343ab6e1f68ab868f9117549e7baecff394e8R1-R17): Introduced a new middleware function `apiKeyMiddleware` to validate the `x-api-key` header against the expected API key from environment variables. Returns a 401 status code for invalid keys.
* [`synced_bloc_server/routes/_middleware.dart`](diffhunk://#diff-87a6ef400fd3e48d8a907b3a4795e7fd76cc6888dbce868bb993ff44df8096b0R2-R5): Integrated the `apiKeyMiddleware` into the server's request handling pipeline, ensuring all routes validate the API key.